### PR TITLE
Added instances for Yoneda, Coyoneda and Ran

### DIFF
--- a/natural-transformation.cabal
+++ b/natural-transformation.cabal
@@ -25,6 +25,7 @@ library
   exposed-modules:     Control.Natural
                        Control.Transformation
   build-depends:       base >= 4.6 && < 5
+                     , kan-extensions         >= 3.7
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/src/Control/Transformation.hs
+++ b/src/Control/Transformation.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE Safe #-}
 {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE InstanceSigs #-}
 
 #if MIN_VERSION_base(4,7,0)
 {-# LANGUAGE PolyKinds #-}
@@ -32,7 +31,7 @@ import           Control.Arrow (Kleisli (..))
 infixr 0 #
 -- | A (natural) transformation is inside @t@, and contains @f@ and @g@
 -- (typically 'Functor's).
--- 
+--
 -- The order of arguments allows the use of @GeneralizedNewtypeDeriving@ to wrap
 -- a ':~>', but maintain the 'Transformation' constraint. Thus, @#@ can be used
 -- on abstract data types.
@@ -40,9 +39,9 @@ class Transformation f g t | t -> f g where
     -- | The invocation method for a natural transformation.
     (#) :: t -> f a -> g a
 
--- {-# RULES "natural free theorem" [~] 
---     forall h (r :: (Functor f, Functor g, Transformation f g t) => t) . 
---     fmap h . (r #) = (r #) . fmap h 
+-- {-# RULES "natural free theorem" [~]
+--     forall h (r :: (Functor f, Functor g, Transformation f g t) => t) .
+--     fmap h . (r #) = (r #) . fmap h
 --   #-}
 
 instance Transformation f g (f :~> g) where
@@ -51,17 +50,17 @@ instance Transformation f g (f :~> g) where
 
 -- data Yoneda f a = Yoneda (forall b. (a -> b) -> f b)
 instance Transformation ((->) a) f (Yoneda f a) where
-  (#) :: Yoneda f a -> (a -> b) -> f b
+  -- (#) :: Yoneda f a -> (a -> b) -> f b
   Yoneda y # f = y f
 
 -- data Coyoneda f a = forall b. Coyoneda (b -> a) (f b)
 instance Functor f => Transformation ((->) a) f (Coyoneda f a) where
-  (#) :: Functor f => Coyoneda f a -> (a -> b) -> f b
+  -- (#) :: Functor f => Coyoneda f a -> (a -> b) -> f b
   Coyoneda f fb # g = fmap (g . f) fb
 
 -- data Kleisli g a b = Kleisli (a -> g b)
 -- data Ran g h a = Ran (forall b. (a -> g b) -> h b)
 instance Transformation (Kleisli g a) h (Ran g h a) where
-  (#) :: Ran g h a -> Kleisli g a b -> h b
+  -- (#) :: Ran g h a -> Kleisli g a b -> h b
   Ran r # Kleisli k = r k
 


### PR DESCRIPTION
I think these are correct. If so, it comes down to whether or not they are too strange and whether you want to depend `kan-extensions`.

These are all specifically natural transformations from a reader functor (or, in the case of `Ran`, reader-like functor).
